### PR TITLE
Use the start-ollama.sh script provided in the official docker image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ $ /llm/ollama/ollama -v
 
 ## References 
 * [Open WebUI documentation](https://docs.openwebui.com/)
-* [Intel - ipex-llm](https://github.com/intel/ipex-llm/blob/main/docs/mddocs/DockerGuides/docker_cpp_xpu_quickstart.md)
+* [Intel ipex-llm releases](https://github.com/intel/ipex-llm/releases)

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -3,7 +3,6 @@
 cd /llm/scripts/
 source ipex-llm-init --gpu --device Arc
 
-mkdir -p /llm/ollama
-cd /llm/ollama
-init-ollama
-./ollama serve
+bash start-ollama.sh
+
+tail -f /dev/null


### PR DESCRIPTION
Use the official script from the Intel Docker image to start the Ollama server, ensuring consistency and best practices for maintainability.