### PR TITLE
Add local tag to image builds in docker-compose files

### DIFF
--- a/docker-compose.comfyui.yml
+++ b/docker-compose.comfyui.yml
@@ -1,11 +1,9 @@
-version: '3'
-
 services:
   comfyui-ipex:
     build:
       context: comfyui
       dockerfile: Dockerfile
-    image: comfyui-ipex:latest
+    image: comfyui-ipex:local
     container_name: comfyui-ipex
     devices:
       - /dev/dri:/dev/dri

--- a/docker-compose.sdnext.yml
+++ b/docker-compose.sdnext.yml
@@ -1,11 +1,9 @@
-version: '3'
-
 services:
   sdnext-ipex:
     build:
       context: sdnext
       dockerfile: Dockerfile
-    image: sdnext-ipex:latest
+    image: sdnext-ipex:local
     container_name: sdnext-ipex
     restart: unless-stopped
     devices:

--- a/docker-compose.whisper.yml
+++ b/docker-compose.whisper.yml
@@ -1,11 +1,9 @@
-version: '3'
-
 services:
   whisper-ipex:
     build:
       context: whisper
       dockerfile: Dockerfile
-    image: whisper-ipex:latest
+    image: whisper-ipex:local
     container_name: whisper-ipex
     restart: unless-stopped
     devices:


### PR DESCRIPTION
Fix: Resolves the issue #13  where `docker-compose` incorrectly attempts to pull images from docker.io.

The root cause was the `image: sdnext-ipex:latest` directive, which forces Docker Compose to validate the image’s existence on Docker Hub.

This PR changes the `docker-compose-*.yml` to define images built by this project as local, preventing this validation step. 

This behavior is not replicated when using Podman, which utilizes a different container runtime. 

This change ensures that Docker Compose only utilizes locally built images, improving build times and preventing potential network issues.