### PR TITLE
Fix: Using heredoc in docker files.

### DIFF
--- a/comfyui/Dockerfile
+++ b/comfyui/Dockerfile
@@ -6,7 +6,12 @@ RUN apt-get update && \
 ENV LD_PRELOAD=libjemalloc.so.2
 
 # Download the ComfyUI repository
-RUN echo '#!/bin/bash\ngit status || git clone https://github.com/comfyanonymous/ComfyUI.git /app \npip install -r /app/requirements.txt \npython /app/main.py "$@"' | tee /bin/startup.sh
+RUN cat <<EOF > /bin/startup.sh
+#!/bin/bash
+git status || git clone https://github.com/comfyanonymous/ComfyUI.git /app
+pip install -r /app/requirements.txt
+python /app/main.py "\$@"
+EOF
 
 # Make the startup script executable
 RUN chmod 755 /bin/startup.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ollama-intel-arc:
     image: intelanalytics/ipex-llm-inference-cpp-xpu:latest

--- a/sdnext/Dockerfile
+++ b/sdnext/Dockerfile
@@ -5,7 +5,11 @@ ENV SD_DATADIR="/mnt/data"
 ENV SD_MODELSDIR="/mnt/models"
 
 # Download the SDNext repository
-RUN echo '#!/bin/bash\ngit status || git clone https://github.com/vladmandic/sdnext.git .\npython /app/launch.py "$@"' | tee /bin/startup.sh
+RUN cat <<EOF > /bin/startup.sh
+#!/bin/bash
+git status || git clone https://github.com/vladmandic/sdnext.git .
+python /app/launch.py "\$@"
+EOF
 
 # Make the startup script executable
 RUN chmod 755 /bin/startup.sh


### PR DESCRIPTION
**What happened?**
The script `/usr/bin/startup.sh` was being created in the Dockerfile using echo with \n in the string.
However, the way it was written, the \n characters were not interpreted as newlines, but as literal backslash-n text.
As a result, the script was a single line with \n in the text, not a valid multi-line shell script.

**Why did this break things?**
Podman had no issues processing the string, but Docker did.
When Docker (or the shell) tried to execute `/usr/bin/startup.sh`, it expected a valid shell script with a proper shebang (#!/bin/bash) on the first line and real commands on the following lines.
Instead, it saw something like:

`#!/bin/bash\ngit status || git clone ...\npython /app/launch.py"$@"`

Bash could not interpret this as a valid script, so it failed with no such file or directory or silently did nothing.

**How was it fixed?**
By using a HEREDOC, the script was written with real newlines between each line.
This made /usr/bin/[startup.sh](https://startup.sh/) a valid shell script, which could be executed as expected.

kudos to @heyyo-droid for the bug report #13 and the fix.