### PR TITLE
Chore/update ollama 0.30.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
-# Copy this file to .env and adjust values as needed.
-
 # =============================================================================
 # Environment: Intel Arc Graphics (Meteor Lake-P, integrated/UMA)
 # =============================================================================
@@ -39,9 +37,11 @@ OLLAMA_DEBUG=0
 # GPU memory; larger contexts reduce the model size that can fully fit.
 OLLAMA_CONTEXT_LENGTH=8192
 
-# Flash attention is NOT supported by the ggml-sycl backend. Must stay false.
-OLLAMA_FLASH_ATTENTION=false
+# Flash attention works correctly on both SYCL and Vulkan paths with this iGPU.
+OLLAMA_FLASH_ATTENTION=true
 
+# q4_0 KV cache: requires flash_attn=true (enforced by llama.cpp). Uses 3.5x less
+# memory than f16 at the same context length, freeing budget for larger models.
 OLLAMA_KV_CACHE_TYPE=q4_0
 OLLAMA_GPU_OVERHEAD=268435456   # 256 MiB — reserves display/overhead memory
 
@@ -66,10 +66,8 @@ OLLAMA_MAX_VRAM=34359738368
 # SYCL / Level Zero performance tuning
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Enable fp16 math in the ggml-sycl backend. Unlike the Vulkan/Mesa path (which
-# has a known fp16 compute bug on this iGPU), Intel's compute-runtime handles
-# fp16 correctly on Arc via Level Zero. Speeds up matrix operations noticeably.
-# If model output looks garbled, disable this first for diagnosis.
+# Enable fp16 math in the ggml-sycl backend. Intel's compute-runtime handles
+# fp16 correctly on Arc via Level Zero. Works correctly with flash attention on.
 GGML_SYCL_F16=1
 
 # Disable SYCL debug output. Referenced in docker-compose so set explicitly

--- a/.env.example
+++ b/.env.example
@@ -54,13 +54,9 @@ OLLAMA_GPU_OVERHEAD=268435456   # 256 MiB — reserves display/overhead memory
 OLLAMA_NUM_GPU=999
 
 # ─────────────────────────────────────────────────────────────────────────────
-# VRAM budget
+# Allow usage of iGPU
 # ─────────────────────────────────────────────────────────────────────────────
-
-# 32 GB soft cap (34359738368 bytes). With 64 GB system RAM and UMA, this
-# allows large models (e.g. 20B+ at Q4) to fully reside in GPU-addressable
-# memory while leaving ~32 GB for the OS, CPU workloads, and KV cache overhead.
-OLLAMA_MAX_VRAM=34359738368
+OLLAMA_IGPU_ENABLE=1
 
 # ─────────────────────────────────────────────────────────────────────────────
 # SYCL / Level Zero performance tuning

--- a/docker-compose.ollama-sycl.yml
+++ b/docker-compose.ollama-sycl.yml
@@ -25,7 +25,7 @@ services:
       # Pass-through from .env — values match recommendation
       - OLLAMA_KEEP_ALIVE
       - OLLAMA_CONTEXT_LENGTH
-      - OLLAMA_MAX_VRAM
+      - OLLAMA_IGPU_ENABLE
       - OLLAMA_NUM_PARALLEL
       - OLLAMA_MAX_LOADED_MODELS
       - OLLAMA_MAX_QUEUE

--- a/docker-compose.ollama-vulkan.yml
+++ b/docker-compose.ollama-vulkan.yml
@@ -1,6 +1,6 @@
 services:
   ollama-vulkan:
-    image: ollama/ollama:0.30.0-rc23
+    image: ollama/ollama:0.30.2
     container_name: ollama-vulkan
     restart: unless-stopped
     devices:

--- a/docker-compose.ollama-vulkan.yml
+++ b/docker-compose.ollama-vulkan.yml
@@ -1,6 +1,6 @@
 services:
   ollama-vulkan:
-    image: ollama/ollama:0.24.0
+    image: ollama/ollama:0.30.0-rc23
     container_name: ollama-vulkan
     restart: unless-stopped
     devices:
@@ -15,15 +15,14 @@ services:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_VULKAN=1
       - GGML_VK_DISABLE_F16=1           # required: Mesa ANV driver has fp16 compute bug on this iGPU
-      - OLLAMA_FLASH_ATTENTION=true
-
       # Pass-through from .env — values match recommendation
+      - OLLAMA_FLASH_ATTENTION
+      - OLLAMA_KV_CACHE_TYPE
       - OLLAMA_NUM_PARALLEL
       - OLLAMA_MAX_LOADED_MODELS
       - OLLAMA_MAX_QUEUE
       - OLLAMA_DEBUG
       - OLLAMA_CONTEXT_LENGTH
-      - OLLAMA_KV_CACHE_TYPE
       - OLLAMA_NUM_GPU
       - OLLAMA_MAX_VRAM
       - OLLAMA_GPU_OVERHEAD

--- a/docker-compose.ollama-vulkan.yml
+++ b/docker-compose.ollama-vulkan.yml
@@ -13,9 +13,12 @@ services:
     environment:
       - no_proxy=localhost,127.0.0.1
       - OLLAMA_HOST=0.0.0.0
+      - ZES_ENABLE_SYSMAN=1
       - OLLAMA_VULKAN=1
-      - GGML_VK_DISABLE_F16=1           # required: Mesa ANV driver has fp16 compute bug on this iGPU
+      #- GGML_VK_DISABLE_F16=1           # required: Mesa ANV driver has fp16 compute bug on this iGPU
       # Pass-through from .env — values match recommendation
+      - GGML_SYCL_F16
+      - GGML_SYCL_DEBUG
       - OLLAMA_FLASH_ATTENTION
       - OLLAMA_KV_CACHE_TYPE
       - OLLAMA_NUM_PARALLEL
@@ -24,7 +27,7 @@ services:
       - OLLAMA_DEBUG
       - OLLAMA_CONTEXT_LENGTH
       - OLLAMA_NUM_GPU
-      - OLLAMA_MAX_VRAM
+      - OLLAMA_IGPU_ENABLE
       - OLLAMA_GPU_OVERHEAD
       - OLLAMA_KEEP_ALIVE
 

--- a/ollama-sycl/Dockerfile
+++ b/ollama-sycl/Dockerfile
@@ -120,9 +120,6 @@ ENV OLLAMA_KEEP_ALIVE=24h
 ENV ZES_ENABLE_SYSMAN=1
 ENV ONEAPI_DEVICE_SELECTOR=level_zero:0
 
-# For Intel Core Ultra Processors (Series 1), code name Meteor Lake
-ENV IPEX_LLM_NPU_MTL=1
-
 EXPOSE 11434
 ENTRYPOINT ["/usr/bin/ollama"]
 CMD ["serve"]

--- a/ollama-sycl/Dockerfile
+++ b/ollama-sycl/Dockerfile
@@ -1,5 +1,4 @@
-ARG OLLAMA_VERSION=0.24.0
-ARG GGML_COMMIT=15bff84bf56651d6f991f166a2bf0f362996f7f9
+ARG OLLAMA_VERSION=0.30.0-rc23
 ARG COMPUTE_RUNTIME_VERSION=26.18.38308.1
 ARG LEVEL_ZERO_VERSION=1.28.2
 ARG IGC_VERSION=2.34.4
@@ -7,53 +6,46 @@ ARG IGC_BUILD=21428
 ARG GMM_VERSION=22.10.0
 
 # =============================================================================
-# Stage 1: Build ggml-sycl backend from ollama's ggml source using Intel oneAPI
+# Stage 1: Build ggml-sycl backend from Ollama source using Intel oneAPI
 # =============================================================================
 FROM intel/oneapi-basekit:2025.2.2-0-devel-ubuntu24.04 AS sycl-builder
 
 ARG OLLAMA_VERSION
-ARG GGML_COMMIT
 
-# Surgically replace Ollama's vendored ggml-sycl with a newer upstream version
+# Clone Ollama at the target version.
 RUN git clone --depth 1 --branch v${OLLAMA_VERSION} \
-  https://github.com/ollama/ollama.git /ollama && \
-  git init /tmp/llama.cpp && \
-  cd /tmp/llama.cpp && \
-  git remote add origin https://github.com/ggml-org/llama.cpp.git && \
-  git sparse-checkout set ggml/src/ggml-sycl && \
-  git fetch --depth 1 origin ${GGML_COMMIT} && \
-  git checkout FETCH_HEAD && \
-  cp -r /tmp/llama.cpp/ggml/src/ggml-sycl \
-  /ollama/ml/backend/ggml/ggml/src/ggml-sycl && \
-  rm -rf /tmp/llama.cpp
+  https://github.com/ollama/ollama.git /ollama
 
 WORKDIR /ollama
 
-# Apply API compatibility patches
-COPY patch-sycl.py /tmp/patch-sycl.py
-RUN python3 /tmp/patch-sycl.py ml/backend/ggml/ggml/src/ggml-sycl/ggml-sycl.cpp
-
-# Build the SYCL backend as a dynamic library
-RUN cmake -B build \
+# Build the SYCL backend via the llama/server cmake subproject.
+# FetchContent downloads the pinned llama.cpp commit (LLAMA_CPP_VERSION) and
+# applies the Ollama compat patch automatically.
+# After the build, find the MODULE (libggml-sycl.so) and copy it to /sycl-runner.
+RUN cmake -S llama/server -B build \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=icx \
   -DCMAKE_CXX_COMPILER=icpx \
+  -DBUILD_SHARED_LIBS=ON \
+  -DGGML_BACKEND_DL=ON \
+  -DGGML_NATIVE=OFF \
+  -DGGML_OPENMP=OFF \
   -DGGML_SYCL=ON \
   -DGGML_SYCL_TARGET=INTEL \
-  -DGGML_SYCL_F16=ON \
-  -DOLLAMA_RUNNER_DIR=sycl && \
-  cmake --build build --parallel $(nproc) --target ggml-sycl
+  -DGGML_SYCL_F16=ON && \
+  cmake --build build --parallel $(nproc) --target ggml-sycl && \
+  mkdir -p /sycl-runner && \
+  find /ollama/build -name "libggml-sycl.so" -exec cp {} /sycl-runner/ \;
 
 # Collect the SYCL runner and its oneAPI runtime dependencies into /sycl-runner
-RUN mkdir -p /sycl-runner && \
-  cp build/lib/ollama/libggml-sycl.so /sycl-runner/ && \
+RUN \
   # SYCL / DPC++ runtime
   cp /opt/intel/oneapi/compiler/latest/lib/libsycl.so* /sycl-runner/ && \
   # Unified Runtime (oneAPI 2025+) — search multiple possible locations
   find /opt/intel/oneapi -name 'libur_loader.so*' | head -3 | xargs -I{} cp {} /sycl-runner/ && \
   find /opt/intel/oneapi -name 'libur_adapter_level_zero.so*' | head -3 | xargs -I{} cp {} /sycl-runner/ && \
   find /opt/intel/oneapi -maxdepth 4 -name 'libumf.so*' | head -3 | xargs -I{} cp {} /sycl-runner/ && \
-  # oneDNN
+  # oneDNN (enabled by GGML_SYCL_DNN=ON default)
   cp /opt/intel/oneapi/dnnl/latest/lib/libdnnl.so* /sycl-runner/ 2>/dev/null; \
   # oneMKL
   cp /opt/intel/oneapi/mkl/latest/lib/libmkl_core.so* /sycl-runner/ && \
@@ -68,12 +60,12 @@ RUN mkdir -p /sycl-runner && \
   cp /opt/intel/oneapi/compiler/latest/lib/libintlc.so* /sycl-runner/ && \
   cp /opt/intel/oneapi/compiler/latest/lib/libirng.so /sycl-runner/ && \
   cp /opt/intel/oneapi/compiler/latest/lib/libiomp5.so /sycl-runner/ && \
-  # Level-zero PI plugin (legacy, may not exist)
+  # Level-zero PI plugin (legacy, may not exist in newer oneAPI)
   cp /opt/intel/oneapi/compiler/latest/lib/libpi_level_zero.so* /sycl-runner/ 2>/dev/null; \
   # SYCL SPIR-V kernels (needed for bfloat16, complex math, etc.)
   cp /opt/intel/oneapi/compiler/latest/lib/libsycl-fallback*.spv /sycl-runner/ && \
   cp /opt/intel/oneapi/compiler/latest/lib/libsycl-native*.spv /sycl-runner/ && \
-  # Strip debug symbols to reduce size
+  # Strip debug symbols to reduce image size
   strip --strip-unneeded /sycl-runner/*.so* 2>/dev/null; true
 
 # =============================================================================
@@ -99,24 +91,23 @@ RUN apt-get update && \
   libhwloc15 && \
   rm -rf /var/lib/apt/lists/*
 
-# Intel GPU runtimes (release 26.05.37020.3)
-# Provides level-zero, IGC, compute-runtime for Intel GPU kernel support
-  RUN mkdir -p /tmp/gpu && cd /tmp/gpu && \
-    wget https://github.com/oneapi-src/level-zero/releases/download/v${LEVEL_ZERO_VERSION}/level-zero_${LEVEL_ZERO_VERSION}+u24.04_amd64.deb && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v${IGC_VERSION}/intel-igc-core-2_${IGC_VERSION}+${IGC_BUILD}_amd64.deb && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v${IGC_VERSION}/intel-igc-opencl-2_${IGC_VERSION}+${IGC_BUILD}_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/intel-ocloc_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/intel-opencl-icd_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/libigdgmm12_${GMM_VERSION}_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/libze-intel-gpu1_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb && \
-    dpkg -i *.deb && rm -rf /tmp/gpu
+# Intel GPU runtimes: Level Zero, IGC, compute-runtime, GMM
+RUN mkdir -p /tmp/gpu && cd /tmp/gpu && \
+  wget https://github.com/oneapi-src/level-zero/releases/download/v${LEVEL_ZERO_VERSION}/level-zero_${LEVEL_ZERO_VERSION}+u24.04_amd64.deb && \
+  wget https://github.com/intel/intel-graphics-compiler/releases/download/v${IGC_VERSION}/intel-igc-core-2_${IGC_VERSION}+${IGC_BUILD}_amd64.deb && \
+  wget https://github.com/intel/intel-graphics-compiler/releases/download/v${IGC_VERSION}/intel-igc-opencl-2_${IGC_VERSION}+${IGC_BUILD}_amd64.deb && \
+  wget https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/intel-ocloc_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb && \
+  wget https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/intel-opencl-icd_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb && \
+  wget https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/libigdgmm12_${GMM_VERSION}_amd64.deb && \
+  wget https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/libze-intel-gpu1_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb && \
+  dpkg -i *.deb && rm -rf /tmp/gpu
 
-# Install official ollama binary + CPU runners (skip CUDA/MLX/Vulkan)
+# Install official ollama binary + CPU runners (skip CUDA/Vulkan)
 RUN wget -qO- "https://github.com/ollama/ollama/releases/download/v${OLLAMA_VERSION}/ollama-linux-amd64.tar.zst" | \
   zstd -d | tar -xf - -C /usr && \
-  rm -rf /usr/lib/ollama/cuda_* /usr/lib/ollama/mlx_* /usr/lib/ollama/vulkan
+  rm -rf /usr/lib/ollama/cuda_* /usr/lib/ollama/vulkan
 
-# Install SYCL runner from build stage
+# Install SYCL runner + oneAPI runtime libs from build stage
 COPY --from=sycl-builder /sycl-runner/ /usr/lib/ollama/sycl/
 
 # Serve ollama on all interfaces
@@ -124,9 +115,6 @@ ENV OLLAMA_HOST=0.0.0.0
 
 # Keep models loaded in memory
 ENV OLLAMA_KEEP_ALIVE=24h
-
-# Flash attention not supported by SYCL backend
-ENV OLLAMA_FLASH_ATTENTION=false
 
 # Intel GPU tuning
 ENV ZES_ENABLE_SYSMAN=1

--- a/ollama-sycl/Dockerfile
+++ b/ollama-sycl/Dockerfile
@@ -1,4 +1,4 @@
-ARG OLLAMA_VERSION=0.30.0-rc23
+ARG OLLAMA_VERSION=0.30.2
 ARG COMPUTE_RUNTIME_VERSION=26.18.38308.1
 ARG LEVEL_ZERO_VERSION=1.28.2
 ARG IGC_VERSION=2.34.4
@@ -39,13 +39,13 @@ RUN cmake -S llama/server -B build \
 
 # Collect the SYCL runner and its oneAPI runtime dependencies into /sycl-runner
 RUN \
-  # SYCL / DPC++ runtime
+  # SYCL / DPC++ runtime \
   cp /opt/intel/oneapi/compiler/latest/lib/libsycl.so* /sycl-runner/ && \
   # Unified Runtime (oneAPI 2025+) — search multiple possible locations
   find /opt/intel/oneapi -name 'libur_loader.so*' | head -3 | xargs -I{} cp {} /sycl-runner/ && \
   find /opt/intel/oneapi -name 'libur_adapter_level_zero.so*' | head -3 | xargs -I{} cp {} /sycl-runner/ && \
   find /opt/intel/oneapi -maxdepth 4 -name 'libumf.so*' | head -3 | xargs -I{} cp {} /sycl-runner/ && \
-  # oneDNN (enabled by GGML_SYCL_DNN=ON default)
+  # oneDNN (enabled by GGML_SYCL_DNN=ON default) \
   cp /opt/intel/oneapi/dnnl/latest/lib/libdnnl.so* /sycl-runner/ 2>/dev/null; \
   # oneMKL
   cp /opt/intel/oneapi/mkl/latest/lib/libmkl_core.so* /sycl-runner/ && \


### PR DESCRIPTION
The official Ollama binary doesn't include libggml-sycl.so. Building it requires Intel's proprietary oneAPI compilers, which aren't part of the upstream release pipeline.

Ollama 0.30+ improves llama.cpp integration enough to make the approach viable: we now compile just that single shared library locally and place it next to the official binary. The Dockerfile is simpler as a result.