### PR TITLE
Chore/update ollama 0.30.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# IDE
+.idea
+
+# Personal / local config
+.env
+plans
+notes.txt
+ollama-sycl/*.py
+benchmark.sh

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ $ cp .env.example .env
 
 Then start Ollama + Open WebUI with the **native SYCL** backend (this builds the Ollama image locally the first time):
 ```bash
-$ podman compose -f docker-compose.ollama-sycl.yml up --build
+$ podman compose -f docker-compose.ollama-sycl.yml up -d --build
 ```
 
 Alternatively, use the **Vulkan** backend (no local build — pulls the stock Ollama image):
 ```bash
-$ podman compose -f docker-compose.ollama-vulkan.yml up
+$ podman compose -f docker-compose.ollama-vulkan.yml up -d
 ```
 
 > The repository also ships a legacy `docker-compose.yml` based on the now-outdated `intelanalytics/ipex-llm-inference-cpp-xpu` image. It is kept for reference only; the native SYCL/Vulkan composes above are the recommended path.
@@ -67,17 +67,17 @@ Additionally, if you want to run one or more of the image generation tools, run 
 
 For ComfyUI
 ```bash
-$ podman compose -f docker-compose.comfyui.yml up
+$ podman compose -f docker-compose.comfyui.yml up -d
 ```
 
 For SD.Next
 ```bash
-$ podman compose -f docker-compose.sdnext.yml up
+$ podman compose -f docker-compose.sdnext.yml up -d
 ```
 
 If you want to run Whisper for automatic speech recognition, run this command in a different terminal:
 ```bash
-$ podman compose -f docker-compose.whisper.yml up
+$ podman compose -f docker-compose.whisper.yml up -d
 ```
 
 ## Configuration
@@ -176,20 +176,20 @@ When using Open WebUI, you should see this partial output in your console, indic
 For the **native SYCL** Ollama image, updates come from rebuilding against a newer Ollama release. Bump `OLLAMA_VERSION` (and, if needed, the Intel GPU driver pins) at the top of [`ollama-sycl/Dockerfile`](ollama-sycl/Dockerfile), then rebuild:
 ```bash
 $ podman compose -f docker-compose.ollama-sycl.yml build --no-cache
-$ podman compose -f docker-compose.ollama-sycl.yml up
+$ podman compose -f docker-compose.ollama-sycl.yml up -d
 ```
 
 For the **Vulkan** image, bump the `ollama/ollama` tag in [`docker-compose.ollama-vulkan.yml`](docker-compose.ollama-vulkan.yml) and pull:
 ```bash
 $ podman compose -f docker-compose.ollama-vulkan.yml pull
-$ podman compose -f docker-compose.ollama-vulkan.yml up
+$ podman compose -f docker-compose.ollama-vulkan.yml up -d
 ```
 
 For Open WebUI and the other `latest`-tagged images, stop the stack and pull:
 ```bash
 $ podman compose -f docker-compose.ollama-sycl.yml down
-$ podman compose -f docker-compose.ollama-sycl.yml pull
-$ podman compose -f docker-compose.ollama-sycl.yml up
+$ podman compose -f docker-compose.ollama-sycl.yml pull open-webui
+$ podman compose -f docker-compose.ollama-sycl.yml up -d
 ```
 
 ## Manually connecting to your Ollama container

--- a/docker-compose.ollama-vulkan.yml
+++ b/docker-compose.ollama-vulkan.yml
@@ -1,6 +1,6 @@
 services:
   ollama-vulkan:
-    image: ollama/ollama:0.30.9
+    image: ollama/ollama:0.30.10
     container_name: ollama-vulkan
     restart: unless-stopped
     devices:
@@ -15,7 +15,7 @@ services:
       - OLLAMA_HOST=0.0.0.0
       - ZES_ENABLE_SYSMAN=1
       - OLLAMA_VULKAN=1
-      #- GGML_VK_DISABLE_F16=1           # required: Mesa ANV driver has fp16 compute bug on this iGPU
+
       # Pass-through from .env — values match recommendation
       - GGML_SYCL_F16
       - GGML_SYCL_DEBUG

--- a/ollama-sycl/Dockerfile
+++ b/ollama-sycl/Dockerfile
@@ -1,4 +1,4 @@
-ARG OLLAMA_VERSION=0.30.9
+ARG OLLAMA_VERSION=0.30.10
 ARG COMPUTE_RUNTIME_VERSION=26.22.38646.4
 ARG LEVEL_ZERO_VERSION=1.28.6
 ARG IGC_VERSION=2.36.3
@@ -41,31 +41,31 @@ RUN cmake -S llama/server -B build \
 RUN \
   # SYCL / DPC++ runtime \
   cp /opt/intel/oneapi/compiler/latest/lib/libsycl.so* /sycl-runner/ && \
-  # Unified Runtime (oneAPI 2025+) — search multiple possible locations
+  # Unified Runtime (oneAPI 2025+)  search multiple possible locations \
   find /opt/intel/oneapi -name 'libur_loader.so*' | head -3 | xargs -I{} cp {} /sycl-runner/ && \
   find /opt/intel/oneapi -name 'libur_adapter_level_zero.so*' | head -3 | xargs -I{} cp {} /sycl-runner/ && \
   find /opt/intel/oneapi -maxdepth 4 -name 'libumf.so*' | head -3 | xargs -I{} cp {} /sycl-runner/ && \
   # oneDNN (enabled by GGML_SYCL_DNN=ON default) \
   cp /opt/intel/oneapi/dnnl/latest/lib/libdnnl.so* /sycl-runner/ 2>/dev/null; \
-  # oneMKL
+  # oneMKL \
   cp /opt/intel/oneapi/mkl/latest/lib/libmkl_core.so* /sycl-runner/ && \
   cp /opt/intel/oneapi/mkl/latest/lib/libmkl_intel_ilp64.so* /sycl-runner/ && \
   cp /opt/intel/oneapi/mkl/latest/lib/libmkl_sycl_blas.so* /sycl-runner/ && \
   cp /opt/intel/oneapi/mkl/latest/lib/libmkl_tbb_thread.so* /sycl-runner/ && \
-  # TBB
+  # TBB \
   cp /opt/intel/oneapi/tbb/latest/lib/intel64/gcc*/libtbb.so* /sycl-runner/ && \
-  # Intel compiler runtime
+  # Intel compiler runtime \
   cp /opt/intel/oneapi/compiler/latest/lib/libsvml.so /sycl-runner/ && \
   cp /opt/intel/oneapi/compiler/latest/lib/libimf.so /sycl-runner/ && \
   cp /opt/intel/oneapi/compiler/latest/lib/libintlc.so* /sycl-runner/ && \
   cp /opt/intel/oneapi/compiler/latest/lib/libirng.so /sycl-runner/ && \
   cp /opt/intel/oneapi/compiler/latest/lib/libiomp5.so /sycl-runner/ && \
-  # Level-zero PI plugin (legacy, may not exist in newer oneAPI)
+  # Level-zero PI plugin (legacy, may not exist in newer oneAPI) \
   cp /opt/intel/oneapi/compiler/latest/lib/libpi_level_zero.so* /sycl-runner/ 2>/dev/null; \
-  # SYCL SPIR-V kernels (needed for bfloat16, complex math, etc.)
+  # SYCL SPIR-V kernels (needed for bfloat16, complex math, etc.) \
   cp /opt/intel/oneapi/compiler/latest/lib/libsycl-fallback*.spv /sycl-runner/ && \
   cp /opt/intel/oneapi/compiler/latest/lib/libsycl-native*.spv /sycl-runner/ && \
-  # Strip debug symbols to reduce image size
+  # Strip debug symbols to reduce image size \
   strip --strip-unneeded /sycl-runner/*.so* 2>/dev/null; true
 
 # =============================================================================

--- a/ollama-sycl/README.md
+++ b/ollama-sycl/README.md
@@ -1,0 +1,98 @@
+# ollama-sycl
+
+A Dockerfile that bolts a SYCL backend onto the official Ollama binary so it
+can run on Intel GPUs (Arc discrete, Arc iGPU / Meteor Lake, Data Center
+Max) via Intel oneAPI and Level Zero.
+
+## Why this image exists
+
+The official `ollama/ollama` Linux release ships these runners: **CUDA,
+Vulkan, CPU** (plus ROCm as a separate download). There is **no SYCL runner**
+in the prebuilt binary.
+
+For Intel GPUs that means two practical options:
+
+| Path | Pros | Cons |
+| --- | --- | --- |
+| Stock image + `OLLAMA_VULKAN=1` | Zero build; works today | Vulkan backend isn't as tuned for Intel GPUs as SYCL; Mesa driver bugs (e.g. fp16 on some iGPUs) |
+| **This image (SYCL)** | Native Intel path via Level Zero + oneMKL/oneDNN; generally best on Intel **discrete** GPUs (benchmark vs Vulkan on iGPUs like Meteor Lake, where Vulkan is competitive) | Requires building from source with Intel's `icx`/`icpx` compilers (~6 GB build image) |
+
+Upstream Ollama doesn't ship a precompiled `libggml-sycl.so` because building
+it requires Intel's proprietary oneAPI compilers. So we build only that one
+shared library locally and drop it next to the official Ollama binary.
+
+## What it builds
+
+A two-stage image:
+
+### Stage 1 — `sycl-builder` (Intel oneAPI basekit, ~6 GB)
+
+1. `git clone` Ollama at the version pinned in `OLLAMA_VERSION`.
+2. Run cmake against `llama/server`.
+   `FetchContent` pulls the pinned llama.cpp commit and applies Ollama's
+   compat patch automatically.
+3. Build *only* the `ggml-sycl` cmake target with `icx`/`icpx`. The result
+   is `libggml-sycl.so`, a dynamically loadable backend module
+   (`GGML_BACKEND_DL=ON`).
+4. Collect the SYCL backend plus every oneAPI runtime `.so` it dlopens
+   (SYCL/DPC++ runtime, Unified Runtime + Level Zero adapter, oneMKL,
+   oneDNN, TBB, Intel compiler runtime, SPIR-V fallback kernels) into
+   `/sycl-runner/`. Strip debug symbols.
+
+### Stage 2 — runtime (`ubuntu:24.04`, ~2 GB)
+1. Install Intel GPU userspace via `.deb`s pinned in `ARG`s:
+   - **Level Zero** loader — required by the SYCL runtime to talk to the GPU.
+   - **IGC** (Intel Graphics Compiler) — JIT-compiles SPIR-V kernels into
+     GPU ISA at runtime.
+   - **compute-runtime** + **GMM** — the Intel OpenCL/Level Zero driver
+     proper. This is what actually executes work on the GPU.
+2. Download the official Ollama Linux tarball at `OLLAMA_VERSION` and
+   extract to `/usr`. Delete `cuda_*` and `vulkan` runners (not needed on
+   Intel; saves ~1 GB).
+3. Copy `/sycl-runner/` from stage 1 into `/usr/lib/ollama/sycl/`. Ollama
+   auto-discovers backends by directory.
+
+## Key cmake flags and why
+
+```
+-DCMAKE_C_COMPILER=icx
+-DCMAKE_CXX_COMPILER=icpx     # SYCL requires Intel's compilers — gcc/clang won't do
+-DBUILD_SHARED_LIBS=ON
+-DGGML_BACKEND_DL=ON          # produce a dlopen-able plugin, not a static lib
+-DGGML_NATIVE=OFF             # don't tune for the build host's CPU — keep portable
+-DGGML_OPENMP=OFF             # avoid OpenMP — clashes with oneAPI's libiomp5
+-DGGML_SYCL=ON
+-DGGML_SYCL_TARGET=INTEL      # build kernels for Intel GPU (not NVIDIA/AMD via oneAPI)
+-DGGML_SYCL_F16=ON            # compile fp16 math support in; toggle at runtime via env
+```
+
+## Pinned versions and how to bump them
+
+| `ARG` | What | When to bump |
+| --- | --- | --- |
+| `OLLAMA_VERSION` | Ollama release tag | New Ollama release. Verify the pinned llama.cpp commit still builds `libggml-sycl.so` correctly and that flash attention + q4_0 KV cache produce correct output. |
+| `COMPUTE_RUNTIME_VERSION` | Intel GPU driver (`intel/compute-runtime`) | Newer GPU support or perf fixes. |
+| `LEVEL_ZERO_VERSION` | Level Zero loader | Usually bump with compute-runtime. |
+| `IGC_VERSION` / `IGC_BUILD` | Intel Graphics Compiler | Usually bump with compute-runtime. |
+| `GMM_VERSION` | Intel GPU memory manager | Usually bump with compute-runtime. |
+
+oneAPI version is pinned via the `intel/oneapi-basekit:2025.2.2-…` tag in
+stage 1's `FROM`.
+
+## Build and run
+
+Built and launched via the repo-root compose file:
+
+```sh
+docker compose -f docker-compose.ollama-sycl.yml up -d --build
+```
+
+This produces the image `ollama-sycl:local` and runs it with `/dev/dri`
+mounted. Runtime tuning (context length, KV cache type, fp16, flash
+attention, etc.) is in `../.env.example` — copy to `.env` and adjust.
+
+## Known issues
+
+- **oneAPI 2025.3.x causes a segfault during warmup** on Xe-LPG (Meteor Lake).
+  Stage 1 is pinned to `intel/oneapi-basekit:2025.2.2`; do not upgrade until
+  the regression is resolved upstream.


### PR DESCRIPTION
- Bumps Ollama to `0.30.10` in both the Vulkan and SYCL configurations.
- Improves README.md
- Add gitignore file